### PR TITLE
Bugfix/upstream stream io fix

### DIFF
--- a/Sources/VaporAWSLambdaRuntime/APIGateway.swift
+++ b/Sources/VaporAWSLambdaRuntime/APIGateway.swift
@@ -20,7 +20,8 @@ struct APIGatewayHandler: EventLoopLambdaHandler {
     }
 
     public func handle(context: Lambda.Context, event: APIGateway.Request)
-        -> EventLoopFuture<APIGateway.Response> {
+        -> EventLoopFuture<APIGateway.Response>
+    {
         let vaporRequest: Vapor.Request
         do {
             vaporRequest = try Vapor.Request(req: event, in: context, for: application)

--- a/Sources/VaporAWSLambdaRuntime/APIGatewayV2.swift
+++ b/Sources/VaporAWSLambdaRuntime/APIGatewayV2.swift
@@ -92,7 +92,6 @@ extension APIGateway.V2.Request: Vapor.StorageKey {
 
 extension APIGateway.V2.Response {
     static func from(response: Vapor.Response, in context: Lambda.Context) -> EventLoopFuture<APIGateway.V2.Response> {
-
         // Create the headers
         var headers = [String: String]()
         response.headers.forEach { name, value in

--- a/Sources/VaporAWSLambdaRuntime/APIGatewayV2.swift
+++ b/Sources/VaporAWSLambdaRuntime/APIGatewayV2.swift
@@ -92,8 +92,6 @@ extension APIGateway.V2.Request: Vapor.StorageKey {
 
 extension APIGateway.V2.Response {
     static func from(response: Vapor.Response, in context: Lambda.Context) -> EventLoopFuture<APIGateway.V2.Response> {
-        // Create the promise
-        let promise = context.eventLoop.makePromise(of: APIGateway.V2.Response.self)
 
         // Create the headers
         var headers = [String: String]()
@@ -142,10 +140,6 @@ extension APIGateway.V2.Response {
                     isBase64Encoded: true
                 )
             }
-            }
         }
-
-        // Return the promise
-        return promise.futureResult
     }
 }

--- a/Sources/VaporAWSLambdaRuntime/APIGatewayV2.swift
+++ b/Sources/VaporAWSLambdaRuntime/APIGatewayV2.swift
@@ -114,7 +114,7 @@ extension APIGateway.V2.Response {
                 isBase64Encoded: false
             ))
         } else if let bytes = response.body.data {
-            promise.succeed(.init(
+            return context.eventLoop.makeSucceededFuture(.init(
                 statusCode: AWSLambdaEvents.HTTPResponseStatus(code: response.status.code),
                 headers: headers,
                 body: String(base64Encoding: bytes),

--- a/Sources/VaporAWSLambdaRuntime/APIGatewayV2.swift
+++ b/Sources/VaporAWSLambdaRuntime/APIGatewayV2.swift
@@ -20,7 +20,8 @@ struct APIGatewayV2Handler: EventLoopLambdaHandler {
     }
 
     public func handle(context: Lambda.Context, event: APIGateway.V2.Request)
-        -> EventLoopFuture<APIGateway.V2.Response> {
+        -> EventLoopFuture<APIGateway.V2.Response>
+    {
         let vaporRequest: Vapor.Request
         do {
             vaporRequest = try Vapor.Request(req: event, in: context, for: application)
@@ -28,8 +29,7 @@ struct APIGatewayV2Handler: EventLoopLambdaHandler {
             return context.eventLoop.makeFailedFuture(error)
         }
 
-        return responder.respond(to: vaporRequest)
-            .map { APIGateway.V2.Response(response: $0) }
+        return responder.respond(to: vaporRequest).flatMap { APIGateway.V2.Response.from(response: $0, in: context) }
     }
 }
 
@@ -59,10 +59,19 @@ extension Vapor.Request {
             nioHeaders.add(name: key, value: value)
         }
 
+        if let cookies = req.cookies, cookies.count > 0 {
+            nioHeaders.add(name: "Cookie", value: cookies.joined(separator: "; "))
+        }
+
+        var url: String = req.rawPath
+        if req.rawQueryString.count > 0 {
+            url += "?\(req.rawQueryString)"
+        }
+
         self.init(
             application: application,
             method: NIOHTTP1.HTTPMethod(rawValue: req.context.http.method.rawValue),
-            url: Vapor.URI(path: req.rawPath),
+            url: Vapor.URI(path: url),
             version: HTTPVersion(major: 1, minor: 1),
             headers: nioHeaders,
             collectedBody: buffer,
@@ -82,32 +91,70 @@ extension APIGateway.V2.Request: Vapor.StorageKey {
 // MARK: - Response -
 
 extension APIGateway.V2.Response {
-    init(response: Vapor.Response) {
+    static func from(response: Vapor.Response, in context: Lambda.Context) -> EventLoopFuture<APIGateway.V2.Response> {
+        // Create the promise
+        let promise = context.eventLoop.makePromise(of: APIGateway.V2.Response.self)
+
+        // Create the headers
         var headers = [String: String]()
         response.headers.forEach { name, value in
-            headers[name] = value
+            if let current = headers[name] {
+                headers[name] = "\(current),\(value)"
+            } else {
+                headers[name] = value
+            }
         }
 
+        // Can we access the body right away?
         if let string = response.body.string {
-            self = .init(
+            promise.succeed(.init(
                 statusCode: AWSLambdaEvents.HTTPResponseStatus(code: response.status.code),
                 headers: headers,
                 body: string,
                 isBase64Encoded: false
-            )
-        } else if var buffer = response.body.buffer {
-            let bytes = buffer.readBytes(length: buffer.readableBytes)!
-            self = .init(
+            ))
+        } else if let bytes = response.body.data {
+            promise.succeed(.init(
                 statusCode: AWSLambdaEvents.HTTPResponseStatus(code: response.status.code),
                 headers: headers,
                 body: String(base64Encoding: bytes),
                 isBase64Encoded: true
-            )
+            ))
         } else {
-            self = .init(
-                statusCode: AWSLambdaEvents.HTTPResponseStatus(code: response.status.code),
-                headers: headers
-            )
+            // See if it is a stream and try to gather the data
+            response.body.collect(on: context.eventLoop).whenComplete { collectResult in
+
+                switch collectResult {
+                case let .failure(error):
+                    promise.fail(error)
+
+                case let .success(buffer):
+
+                    // Was there any content
+                    guard
+                        var buffer = buffer,
+                        let bytes = buffer.readBytes(length: buffer.readableBytes)
+                    else {
+                        promise.succeed(.init(
+                            statusCode: AWSLambdaEvents.HTTPResponseStatus(code: response.status.code),
+                            headers: headers
+                        ))
+
+                        return
+                    }
+
+                    // Done
+                    promise.succeed(.init(
+                        statusCode: AWSLambdaEvents.HTTPResponseStatus(code: response.status.code),
+                        headers: headers,
+                        body: String(base64Encoding: bytes),
+                        isBase64Encoded: true
+                    ))
+                }
+            }
         }
+
+        // Return the promise
+        return promise.futureResult
     }
 }

--- a/Sources/VaporAWSLambdaRuntime/APIGatewayV2.swift
+++ b/Sources/VaporAWSLambdaRuntime/APIGatewayV2.swift
@@ -83,17 +83,15 @@ extension APIGateway.V2.Request: Vapor.StorageKey {
 
 extension APIGateway.V2.Response {
     init(response: Vapor.Response) {
-        var headers = [String: [String]]()
+        var headers = [String: String]()
         response.headers.forEach { name, value in
-            var values = headers[name] ?? [String]()
-            values.append(value)
-            headers[name] = values
+            headers[name] = value
         }
 
         if let string = response.body.string {
             self = .init(
                 statusCode: AWSLambdaEvents.HTTPResponseStatus(code: response.status.code),
-                multiValueHeaders: headers,
+                headers: headers,
                 body: string,
                 isBase64Encoded: false
             )
@@ -101,14 +99,14 @@ extension APIGateway.V2.Response {
             let bytes = buffer.readBytes(length: buffer.readableBytes)!
             self = .init(
                 statusCode: AWSLambdaEvents.HTTPResponseStatus(code: response.status.code),
-                multiValueHeaders: headers,
+                headers: headers,
                 body: String(base64Encoding: bytes),
                 isBase64Encoded: true
             )
         } else {
             self = .init(
                 statusCode: AWSLambdaEvents.HTTPResponseStatus(code: response.status.code),
-                multiValueHeaders: headers
+                headers: headers
             )
         }
     }

--- a/Sources/VaporAWSLambdaRuntime/APIGatewayV2.swift
+++ b/Sources/VaporAWSLambdaRuntime/APIGatewayV2.swift
@@ -107,7 +107,7 @@ extension APIGateway.V2.Response {
 
         // Can we access the body right away?
         if let string = response.body.string {
-            promise.succeed(.init(
+            return context.eventLoop.makeSucceededFuture(.init(
                 statusCode: AWSLambdaEvents.HTTPResponseStatus(code: response.status.code),
                 headers: headers,
                 body: string,

--- a/Sources/VaporAWSLambdaRuntime/LambdaServer.swift
+++ b/Sources/VaporAWSLambdaRuntime/LambdaServer.swift
@@ -100,7 +100,8 @@ public class LambdaServer: Server {
     init(application: Application,
          responder: Responder,
          configuration: Configuration,
-         on eventLoopGroup: EventLoopGroup) {
+         on eventLoopGroup: EventLoopGroup)
+    {
         self.application = application
         self.responder = responder
         self.configuration = configuration


### PR DESCRIPTION
This PR would replace my previous PR. While running a Leaf based app, I noticed that the CSS and JavaScript files were not being served up properly. They were returning status code 200, but contained 0 bytes. I discovered that the FileMiddleware is using streaming for the files, but the conversion from Vapor Response to Lambda response did not handle this case.

I have fixed this, but I had to change the API a little because the fix requires the use of promises and event loops. 

I spent a little time looking into doing some tests, but that requires creating a Lambda.Context object and all the APIs I could find for doing are marked internal and are therefore inaccessible. If you have any pointers into how I might do that, I would be happy to look into creating some test requests.