### PR TITLE
Update CI and fix build errors for Swift 5.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,14 +27,13 @@ jobs:
         images:
         - swift:5.2-amazonlinux2
         - swift:5.3-amazonlinux2
+        - swift:5.4-amazonlinux2
+        - swiftlang/swift:nightly-5.5-amazonlinux2
     container:
       image: ${{ matrix.images }}
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Install dependencies 
-      if: contains(matrix.images, 'amazonlinux2') == false
-      run: apt-get update && apt-get install -y curl # required by the codecov action.
     - name: Test
       run: swift test --enable-code-coverage --enable-test-discovery
     - name: Convert coverage files
@@ -53,6 +52,8 @@ jobs:
         images:
         - swift:5.2-amazonlinux2
         - swift:5.3-amazonlinux2
+        - swift:5.4-amazonlinux2
+        - swiftlang/swift:nightly-5.5-amazonlinux2
     defaults:
       run:
         working-directory: examples/${{ matrix.examples }}
@@ -72,18 +73,19 @@ jobs:
       fail-fast: false
       matrix:
         xcode:
-        - Xcode_11.6.app
-        - Xcode_12.2.app
+        - 11.7 # Swift 5.2
+        - 12.4 # Swift 5.3
+        - 12.5 # Swift 5.4
+        - latest
     steps:
     - name: Checkout
       uses: actions/checkout@v1
-    - name: Show all Xcode versions
-      run: ls -an /Applications/ | grep Xcode*
-    - name: Change Xcode command line tools
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}/Contents/Developer
+    - uses: maxim-lobanov/setup-xcode@v1.2.3
+      with:
+        xcode-version: ${{ matrix.xcode }}
     - name: Xcode Tests
       run: |
-        swift package generate-xcodeproj
-        xcodebuild -quiet -parallel-testing-enabled YES -scheme vapor-aws-lambda-runtime-Package -enableCodeCoverage YES build test
-    - name: Codecov
-      run: bash <(curl -s https://codecov.io/bash) -t ${{secrets.CODECOV_TOKEN}}
+        swift test --enable-code-coverage
+        xcrun llvm-cov export -format="lcov" .build/debug/ApodiniPackageTests.xctest/Contents/MacOS/ApodiniPackageTests -instr-profile .build/debug/codecov/default.profdata > coverage.lcov
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,14 +68,13 @@ jobs:
       run: swift build -c release
 
   "macOS-Tests":
-    runs-on: macos-11
+    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
         xcode:
         - 11.7 # Swift 5.2
         - 12.4 # Swift 5.3
-        - 12.5 # Swift 5.4
         - latest
     steps:
     - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,7 @@ jobs:
       run: swift build -c release
 
   "macOS-Tests":
-    runs-on: macOS-latest
+    runs-on: macos-11
     strategy:
       fail-fast: false
       matrix:
@@ -84,8 +84,10 @@ jobs:
       with:
         xcode-version: ${{ matrix.xcode }}
     - name: Xcode Tests
-      run: |
-        swift test --enable-code-coverage
-        xcrun llvm-cov export -format="lcov" .build/debug/ApodiniPackageTests.xctest/Contents/MacOS/ApodiniPackageTests -instr-profile .build/debug/codecov/default.profdata > coverage.lcov
+      run: swift test --enable-code-coverage
+    - name: Generate Coverage Report
+      if: matrix.xcode == 'latest'
+      run: xcrun llvm-cov export -format="lcov" .build/debug/vapor-aws-lambda-runtimePackageTests.xctest/Contents/MacOS/vapor-aws-lambda-runtimePackageTests -instr-profile .build/debug/codecov/default.profdata > coverage.lcov
     - name: Upload coverage to Codecov
+      if: matrix.xcode == 'latest'
       uses: codecov/codecov-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ packaged.yaml
 examples/**/bootstrap
 examples/**/lambda.zip
 /Package.resolved
+.swiftpm

--- a/Sources/VaporAWSLambdaRuntime/APIGateway.swift
+++ b/Sources/VaporAWSLambdaRuntime/APIGateway.swift
@@ -72,7 +72,7 @@ extension Vapor.Request {
             on: ctx.eventLoop
         )
 
-        storage[APIGateway.Request] = req
+        storage[APIGateway.Request.self] = req
     }
 }
 

--- a/Sources/VaporAWSLambdaRuntime/APIGatewayV2.swift
+++ b/Sources/VaporAWSLambdaRuntime/APIGatewayV2.swift
@@ -80,7 +80,7 @@ extension Vapor.Request {
             on: ctx.eventLoop
         )
 
-        storage[APIGateway.V2.Request] = req
+        storage[APIGateway.V2.Request.self] = req
     }
 }
 

--- a/Sources/VaporAWSLambdaRuntime/APIGatewayV2.swift
+++ b/Sources/VaporAWSLambdaRuntime/APIGatewayV2.swift
@@ -119,7 +119,7 @@ extension APIGateway.V2.Response {
             ))
         } else {
             // See if it is a stream and try to gather the data
-            return response.body.collect(on: context.eventLoop).map { (buffer) -> APIGateway.V2.Response in
+            return response.body.collect(on: context.eventLoop).map { buffer -> APIGateway.V2.Response in
                 // Was there any content
                 guard
                     var buffer = buffer,

--- a/examples/Hello/Sources/Hello/main.swift
+++ b/examples/Hello/Sources/Hello/main.swift
@@ -11,7 +11,7 @@ struct Hello: Content {
     let hello: String
 }
 
-app.get("hello") { (_) -> Hello in
+app.get("hello") { _ -> Hello in
     Hello(hello: "world")
 }
 


### PR DESCRIPTION
When checking out the vapor-aws-lambda-runtime package I noted that it fails to compile on Linux for Swift 5.5. I have updated the package to build on Swift 5.5 and have updated the CI to reflect that support.
The changes are very small: There was a missing `.self` in both APIGateway.swift  and APIGatewayV2.swift. 

Unfortunately macOS 11 support is still in private preview so I can not update the macOS builds to Swift 5.4 or Swift 5.5 and I could not test this using GitHub Actions in my fork. It builds without any problems locally. The following GitHub Actions runs verify the behavior for Swift 5.4 and Swift 5.5: https://github.com/PSchmiedmayer/vapor-aws-lambda-runtime/actions/runs/985680292

Adding CI support for Swift 5.4 and 5.5 on macOS should is easily doable once the `vapor-community` organization has access to macOS 11 by changing the GitHub Action file in the following way for macOS builds:
```yml
  "macOS-Tests":
    runs-on: macos-11
    strategy:
      fail-fast: false
      matrix:
        xcode:
        - 11.7 # Swift 5.2
        - 12.4 # Swift 5.3
        - 12.5 # Swift 5.4
        - latest
    steps:
    - name: Checkout
      uses: actions/checkout@v1
    - uses: maxim-lobanov/setup-xcode@v1.2.3
      with:
        xcode-version: ${{ matrix.xcode }}
    - name: Xcode Tests
      run: swift test --enable-code-coverage
    - name: Generate Coverage Report
      if: matrix.xcode == 'latest'
      run: xcrun llvm-cov export -format="lcov" .build/debug/vapor-aws-lambda-runtimePackageTests.xctest/Contents/MacOS/vapor-aws-lambda-runtimePackageTests -instr-profile .build/debug/codecov/default.profdata > coverage.lcov
    - name: Upload coverage to Codecov
      if: matrix.xcode == 'latest'
      uses: codecov/codecov-action@v1
```